### PR TITLE
Add code tab tags around code tags

### DIFF
--- a/docs/Introduction/index.md
+++ b/docs/Introduction/index.md
@@ -9,7 +9,7 @@ There are different components to SDL that make everything work. The following d
 <br><br>
 ![High Level Diagram](assets/HighLevelDiagram.png) 
 
-
+|~
 ```objc
 #import <Foundation/Foundation.h>
 
@@ -27,7 +27,7 @@ int main(int argc, const char * argv[]) {
 import Swift
 print("Hello, World!")
 ```
-
+~|
 
 ## Sections
 


### PR DESCRIPTION
This would be to test the Livio-proposed code tab tags `|~ .. ~|` denoting where a set of code snippets should appear tabulated when built.
Reference Trello Card 835: https://trello.com/c/KmQOT5Bf/835-20-hrs-be-newlines-between-sequential-fenced-code-blocks-still-result-in-tabs